### PR TITLE
feat(db): configurar banco de dados e ORM

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# FundamentAI Backend

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,0 +1,187 @@
+"""
+Modelos SQLAlchemy para o FundamentAI.
+
+Tabelas:
+- Ticker: ações e FIIs cadastrados no sistema
+- FinancialData: dados financeiros brutos coletados (DRE, Balanço)
+- Indicators: indicadores fundamentalistas calculados
+- Analysis: análises geradas pela LLM (veredito, score, etc.)
+"""
+
+import os
+from datetime import datetime
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./fundamentai.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Ticker(Base):
+    """Ações e FIIs cadastrados no sistema."""
+
+    __tablename__ = "tickers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    symbol = Column(String(10), unique=True, nullable=False, index=True)
+    name = Column(String(200), nullable=True)
+    sector = Column(String(100), nullable=True)
+    segment = Column(String(100), nullable=True)
+    asset_type = Column(String(20), nullable=True)  # "stock" | "fii"
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    financial_data = relationship("FinancialData", back_populates="ticker", cascade="all, delete-orphan")
+    indicators = relationship("Indicators", back_populates="ticker", cascade="all, delete-orphan")
+    analyses = relationship("Analysis", back_populates="ticker", cascade="all, delete-orphan")
+
+    def __repr__(self) -> str:
+        return f"<Ticker(symbol={self.symbol}, name={self.name})>"
+
+
+class FinancialData(Base):
+    """Dados financeiros brutos coletados (DRE, Balanço Patrimonial, cotação)."""
+
+    __tablename__ = "financial_data"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticker_id = Column(Integer, ForeignKey("tickers.id"), nullable=False, index=True)
+    reference_date = Column(DateTime, nullable=False, index=True)
+
+    # Cotação
+    current_price = Column(Float, nullable=True)
+    market_cap = Column(Float, nullable=True)
+
+    # DRE (Demonstração do Resultado do Exercício)
+    revenue = Column(Float, nullable=True)           # Receita líquida
+    net_income = Column(Float, nullable=True)        # Lucro líquido
+    ebitda = Column(Float, nullable=True)            # EBITDA
+    gross_profit = Column(Float, nullable=True)      # Lucro bruto
+
+    # Balanço Patrimonial
+    total_assets = Column(Float, nullable=True)      # Ativo total
+    total_equity = Column(Float, nullable=True)      # Patrimônio líquido
+    total_debt = Column(Float, nullable=True)        # Dívida total
+    net_debt = Column(Float, nullable=True)          # Dívida líquida
+    invested_capital = Column(Float, nullable=True)  # Capital investido
+
+    # Dados brutos em JSON (para flexibilidade)
+    raw_data = Column(Text, nullable=True)
+
+    collected_at = Column(DateTime, default=datetime.utcnow)
+
+    ticker = relationship("Ticker", back_populates="financial_data")
+
+    def __repr__(self) -> str:
+        return f"<FinancialData(ticker_id={self.ticker_id}, date={self.reference_date})>"
+
+
+class Indicators(Base):
+    """Indicadores fundamentalistas calculados."""
+
+    __tablename__ = "indicators"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticker_id = Column(Integer, ForeignKey("tickers.id"), nullable=False, index=True)
+    reference_date = Column(DateTime, nullable=False, index=True)
+
+    # Rentabilidade
+    roe = Column(Float, nullable=True)               # Retorno sobre Patrimônio (%)
+    roic = Column(Float, nullable=True)              # Retorno sobre Capital Investido (%)
+    net_margin = Column(Float, nullable=True)        # Margem líquida (%)
+
+    # Endividamento
+    debt_ebitda = Column(Float, nullable=True)       # Dívida líquida / EBITDA
+
+    # Valuation
+    pe_ratio = Column(Float, nullable=True)          # P/L (Preço / Lucro)
+    pb_ratio = Column(Float, nullable=True)          # P/VP (Preço / Valor Patrimonial)
+
+    # Crescimento (YoY)
+    revenue_growth_yoy = Column(Float, nullable=True)    # Crescimento de receita (%)
+    net_income_growth_yoy = Column(Float, nullable=True) # Crescimento de lucro (%)
+
+    # Score calculado
+    score = Column(Float, nullable=True)             # Score fundamentalista (0-100)
+    score_label = Column(String(20), nullable=True)  # Excelente | Bom | Regular | Fraco
+
+    calculated_at = Column(DateTime, default=datetime.utcnow)
+
+    ticker = relationship("Ticker", back_populates="indicators")
+
+    def __repr__(self) -> str:
+        return f"<Indicators(ticker_id={self.ticker_id}, score={self.score})>"
+
+
+class Analysis(Base):
+    """Análises geradas pela LLM (Anthropic Claude)."""
+
+    __tablename__ = "analyses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticker_id = Column(Integer, ForeignKey("tickers.id"), nullable=False, index=True)
+
+    # Resultado da análise
+    verdict = Column(String(50), nullable=True)          # Ex: "Positivo", "Neutro", "Negativo"
+    score = Column(Float, nullable=True)                 # Score 0-100
+    confidence_level = Column(String(20), nullable=True) # "Alto" | "Médio" | "Baixo"
+
+    # Conteúdo estruturado
+    positive_points = Column(Text, nullable=True)        # JSON array de pontos positivos
+    negative_points = Column(Text, nullable=True)        # JSON array de pontos negativos
+    indicators_explanation = Column(Text, nullable=True) # Explicação dos indicadores
+    conclusion = Column(Text, nullable=True)             # Conclusão geral
+    moment_suggestion = Column(Text, nullable=True)      # Sugestão de momento (não recomendação)
+
+    # Metadados da geração
+    model_used = Column(String(50), nullable=True)       # claude-sonnet-4-5 | claude-haiku-4-5
+    prompt_version = Column(String(20), nullable=True)   # Versão do template de prompt
+    raw_response = Column(Text, nullable=True)           # Resposta bruta da LLM
+
+    generated_at = Column(DateTime, default=datetime.utcnow)
+
+    ticker = relationship("Ticker", back_populates="analyses")
+
+    def __repr__(self) -> str:
+        return f"<Analysis(ticker_id={self.ticker_id}, verdict={self.verdict}, score={self.score})>"
+
+
+def create_tables() -> None:
+    """Cria todas as tabelas no banco de dados."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """
+    Dependency para injeção de sessão do banco nas rotas FastAPI.
+
+    Uso:
+        @app.get("/example")
+        def example(db: Session = Depends(get_db)):
+            ...
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/db/repository.py
+++ b/backend/db/repository.py
@@ -1,0 +1,248 @@
+"""
+Repository pattern para acesso ao banco de dados.
+
+Abstrai as operações CRUD para cada entidade, mantendo a lógica de
+persistência separada das rotas da API e do ETL.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.db.models import Analysis, FinancialData, Indicators, Ticker
+
+
+# ---------------------------------------------------------------------------
+# Ticker
+# ---------------------------------------------------------------------------
+
+
+class TickerRepository:
+    """Operações CRUD para a entidade Ticker."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_by_symbol(self, symbol: str) -> Optional[Ticker]:
+        """Busca um ticker pelo símbolo (ex: PETR4)."""
+        return self.db.query(Ticker).filter(Ticker.symbol == symbol.upper()).first()
+
+    def get_all(self) -> list[Ticker]:
+        """Retorna todos os tickers cadastrados."""
+        return self.db.query(Ticker).all()
+
+    def create(
+        self,
+        symbol: str,
+        name: Optional[str] = None,
+        sector: Optional[str] = None,
+        segment: Optional[str] = None,
+        asset_type: Optional[str] = "stock",
+    ) -> Ticker:
+        """Cria um novo ticker."""
+        ticker = Ticker(
+            symbol=symbol.upper(),
+            name=name,
+            sector=sector,
+            segment=segment,
+            asset_type=asset_type,
+        )
+        self.db.add(ticker)
+        self.db.commit()
+        self.db.refresh(ticker)
+        return ticker
+
+    def get_or_create(self, symbol: str, **kwargs) -> tuple[Ticker, bool]:
+        """
+        Retorna o ticker existente ou cria um novo.
+
+        Returns:
+            (ticker, created): ticker e flag indicando se foi criado agora.
+        """
+        ticker = self.get_by_symbol(symbol)
+        if ticker:
+            return ticker, False
+        ticker = self.create(symbol, **kwargs)
+        return ticker, True
+
+    def update(self, ticker: Ticker, **kwargs) -> Ticker:
+        """Atualiza campos de um ticker existente."""
+        for key, value in kwargs.items():
+            if hasattr(ticker, key):
+                setattr(ticker, key, value)
+        ticker.updated_at = datetime.utcnow()
+        self.db.commit()
+        self.db.refresh(ticker)
+        return ticker
+
+    def delete(self, ticker: Ticker) -> None:
+        """Remove um ticker e todos os dados associados (cascade)."""
+        self.db.delete(ticker)
+        self.db.commit()
+
+
+# ---------------------------------------------------------------------------
+# FinancialData
+# ---------------------------------------------------------------------------
+
+
+class FinancialDataRepository:
+    """Operações CRUD para dados financeiros brutos."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_latest(self, ticker_id: int) -> Optional[FinancialData]:
+        """Retorna o registro mais recente de dados financeiros para um ticker."""
+        return (
+            self.db.query(FinancialData)
+            .filter(FinancialData.ticker_id == ticker_id)
+            .order_by(FinancialData.reference_date.desc())
+            .first()
+        )
+
+    def get_history(self, ticker_id: int, limit: int = 20) -> list[FinancialData]:
+        """Retorna o histórico de dados financeiros para um ticker."""
+        return (
+            self.db.query(FinancialData)
+            .filter(FinancialData.ticker_id == ticker_id)
+            .order_by(FinancialData.reference_date.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def create(self, ticker_id: int, reference_date: datetime, **kwargs) -> FinancialData:
+        """Cria um novo registro de dados financeiros."""
+        financial_data = FinancialData(
+            ticker_id=ticker_id,
+            reference_date=reference_date,
+            **kwargs,
+        )
+        self.db.add(financial_data)
+        self.db.commit()
+        self.db.refresh(financial_data)
+        return financial_data
+
+    def upsert(self, ticker_id: int, reference_date: datetime, **kwargs) -> FinancialData:
+        """
+        Cria ou atualiza dados financeiros para uma data de referência.
+        Evita duplicatas para o mesmo ticker + data.
+        """
+        existing = (
+            self.db.query(FinancialData)
+            .filter(
+                FinancialData.ticker_id == ticker_id,
+                FinancialData.reference_date == reference_date,
+            )
+            .first()
+        )
+        if existing:
+            for key, value in kwargs.items():
+                if hasattr(existing, key):
+                    setattr(existing, key, value)
+            self.db.commit()
+            self.db.refresh(existing)
+            return existing
+        return self.create(ticker_id, reference_date, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Indicators
+# ---------------------------------------------------------------------------
+
+
+class IndicatorsRepository:
+    """Operações CRUD para indicadores fundamentalistas calculados."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_latest(self, ticker_id: int) -> Optional[Indicators]:
+        """Retorna os indicadores mais recentes para um ticker."""
+        return (
+            self.db.query(Indicators)
+            .filter(Indicators.ticker_id == ticker_id)
+            .order_by(Indicators.reference_date.desc())
+            .first()
+        )
+
+    def get_history(self, ticker_id: int, limit: int = 20) -> list[Indicators]:
+        """Retorna o histórico de indicadores para um ticker."""
+        return (
+            self.db.query(Indicators)
+            .filter(Indicators.ticker_id == ticker_id)
+            .order_by(Indicators.reference_date.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def create(self, ticker_id: int, reference_date: datetime, **kwargs) -> Indicators:
+        """Cria um novo registro de indicadores."""
+        indicators = Indicators(
+            ticker_id=ticker_id,
+            reference_date=reference_date,
+            **kwargs,
+        )
+        self.db.add(indicators)
+        self.db.commit()
+        self.db.refresh(indicators)
+        return indicators
+
+    def upsert(self, ticker_id: int, reference_date: datetime, **kwargs) -> Indicators:
+        """Cria ou atualiza indicadores para uma data de referência."""
+        existing = (
+            self.db.query(Indicators)
+            .filter(
+                Indicators.ticker_id == ticker_id,
+                Indicators.reference_date == reference_date,
+            )
+            .first()
+        )
+        if existing:
+            for key, value in kwargs.items():
+                if hasattr(existing, key):
+                    setattr(existing, key, value)
+            self.db.commit()
+            self.db.refresh(existing)
+            return existing
+        return self.create(ticker_id, reference_date, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+class AnalysisRepository:
+    """Operações CRUD para análises geradas pela LLM."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_latest(self, ticker_id: int) -> Optional[Analysis]:
+        """Retorna a análise mais recente para um ticker."""
+        return (
+            self.db.query(Analysis)
+            .filter(Analysis.ticker_id == ticker_id)
+            .order_by(Analysis.generated_at.desc())
+            .first()
+        )
+
+    def get_history(self, ticker_id: int, limit: int = 10) -> list[Analysis]:
+        """Retorna o histórico de análises para um ticker."""
+        return (
+            self.db.query(Analysis)
+            .filter(Analysis.ticker_id == ticker_id)
+            .order_by(Analysis.generated_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def create(self, ticker_id: int, **kwargs) -> Analysis:
+        """Cria um novo registro de análise."""
+        analysis = Analysis(ticker_id=ticker_id, **kwargs)
+        self.db.add(analysis)
+        self.db.commit()
+        self.db.refresh(analysis)
+        return analysis


### PR DESCRIPTION
## O que foi feito

Implementa a camada de persistência do FundamentAI usando SQLAlchemy como ORM.

**Modelos criados (`backend/db/models.py`):**
- `Ticker` — ações e FIIs cadastrados no sistema
- `FinancialData` — dados financeiros brutos (DRE, Balanço, cotação)
- `Indicators` — indicadores fundamentalistas calculados
- `Analysis` — análises geradas pela LLM

**Repository pattern (`backend/db/repository.py`):**
- `TickerRepository` — CRUD + `get_or_create`
- `FinancialDataRepository` — CRUD + `upsert` por ticker/data
- `IndicatorsRepository` — CRUD + `upsert` por ticker/data
- `AnalysisRepository` — CRUD + histórico

## Por que foi feito

Fundação da camada de persistência. Todos os dados coletados e processados pelo ETL e pela API são armazenados aqui.

## Como testar

```bash
pip install -r backend/requirements.txt
python -c "from backend.db.models import create_tables; create_tables(); print('OK')"
```

## Issue relacionada

Closes #13
