### PR TITLE
Feat/implementar tratamento de retorno sem chave anthropic configurada

### DIFF
--- a/.kiro/prompt-logs/feat-implementar-tratamento-de-retorno-sem-chave-anthropic-configurada.md
+++ b/.kiro/prompt-logs/feat-implementar-tratamento-de-retorno-sem-chave-anthropic-configurada.md
@@ -1,0 +1,66 @@
+# Prompt Logs: feat/implementar-tratamento-de-retorno-sem-chave-anthropic-configurada
+
+Histórico de prompts executados no Kiro nesta branch.
+
+---
+
+## Prompt: no backend temos uma chave da anthropic que pode s...
+- Responsável: Fábio José Pegoraro
+- Branch: feat/implementar-tratamento-de-retorno-sem-chave-anthropic-configurada
+- Data/hora: 2026-05-19 21:17:21 (Brasília)
+
+### Prompt original
+```
+no backend temos uma chave da anthropic que pode ser configurada no arquivo .env na raiz do projeto.No arquivo backend/api/routes/analysis.py verificamos se a chave está configurada. Caso não esteja, o backend retorna um json padrão para o front com dados de mock e este dados estão sendo exibidos no frontend como se fosse o resultado retornado pela anthropic.Preciso que, caso a chave não esteja configurada, o retorno do backend informe que a chave não está configurada ao invés de dados de mock como está hoje.
+```
+
+---
+
+## Prompt: faça apenas a correção do backend. Não faça commit...
+- Responsável: Fábio José Pegoraro
+- Branch: feat/implementar-tratamento-de-retorno-sem-chave-anthropic-configurada
+- Data/hora: 2026-05-19 21:18:42 (Brasília)
+
+### Prompt original
+```
+faça apenas a correção do backend. Não faça commit. Não faça push da branch.
+```
+
+---
+
+## Prompt: no backend temos uma chave da anthropic que pode s...
+- Responsável: Fábio José Pegoraro
+- Branch: feat/implementar-tratamento-de-retorno-sem-chave-anthropic-configurada
+- Data/hora: 2026-05-19 21:20:19 (Brasília)
+
+### Prompt original
+```
+no backend temos uma chave da anthropic que pode ser configurada no arquivo .env na raiz do projeto.No arquivo backend/api/routes/analysis.py verificamos se a chave está configurada. Caso não esteja, o backend retorna um json padrão para o front com dados de mock e este dados estão sendo exibidos no frontend como se fosse o resultado retornado pela anthropic.Preciso que, caso a chave não esteja configurada, o retorno do backend informe que a chave não está configurada ao invés de dados de mock como está hoje.Faça apenas a correção do backend.Não faça commit.Não faça push da branch.
+```
+
+---
+
+## Prompt: Agora vamos ajustar o frontend.O retorno 503 da AP...
+- Responsável: Fábio José Pegoraro
+- Branch: feat/implementar-tratamento-de-retorno-sem-chave-anthropic-configurada
+- Data/hora: 2026-05-19 21:47:30 (Brasília)
+
+### Prompt original
+```
+Agora vamos ajustar o frontend.O retorno 503 da API está ocorrendo quando pesquiso por um ticker na página principal do sistema sendo que deveria ocorrer somente se o usuário clica a aba IA e a chave da anthropic não está configurada.Separe estas chamadas no frontend deixando a chamada com a chave da anthropic apenas para quando o usuário clicar na aba IA.
+```
+
+---
+
+## Prompt: Agora vamos ajustar o frontend.O retorno 503 da AP...
+- Responsável: Fábio José Pegoraro
+- Branch: feat/implementar-tratamento-de-retorno-sem-chave-anthropic-configurada
+- Data/hora: 2026-05-19 21:47:57 (Brasília)
+
+### Prompt original
+```
+Agora vamos ajustar o frontend.O retorno 503 da API está ocorrendo quando pesquiso por um ticker na página principal do sistema sendo que deveria ocorrer somente se o usuário clica a aba IA e a chave da anthropic não está configurada.Separe estas chamadas no frontend deixando a chamada com a chave da anthropic apenas para quando o usuário clicar na aba IA.
+```
+
+---
+

--- a/backend/api/routes/analysis.py
+++ b/backend/api/routes/analysis.py
@@ -283,36 +283,14 @@ def _call_anthropic(system_prompt: str, user_prompt: str, model: str) -> str:
     """
     api_key = os.getenv("ANTHROPIC_API_KEY")
     if not api_key or api_key == "lac-to-cocos":
-        logger.warning("ANTHROPIC_API_KEY ausente ou inválida. Retornando dados mockados.")
-        return """
-        {
-          "verdict": "Compra (Mock)",
-          "score": 85.5,
-          "confidence_level": "Alto",
-          "positive_points": [
-            "Excelente retorno sobre patrimônio (ROE)",
-            "Baixo nível de endividamento",
-            "Margens saudáveis em comparação ao setor"
-          ],
-          "negative_points": [
-            "Setor altamente sensível à taxa de juros",
-            "Crescimento de receita estável, mas sem grandes saltos recentes"
-          ],
-          "indicators_explanation": {
-            "roe": "A empresa tem uma ótima eficiência em gerar lucros com o dinheiro dos acionistas.",
-            "roic": "O retorno sobre os investimentos feitos no negócio é muito atrativo.",
-            "net_margin": "Sobra uma boa fatia de lucro para cada Real vendido.",
-            "debt_ebitda": "A dívida está totalmente sob controle e pode ser paga facilmente com a geração de caixa atual.",
-            "pe_ratio": "A ação está sendo negociada a um preço justo em relação ao lucro que gera.",
-            "pb_ratio": "O mercado valoriza o patrimônio da empresa, o que é um bom sinal.",
-            "growth": "A empresa mantém um crescimento contínuo, embora mais conservador nos últimos anos."
-          },
-          "moment_suggestion": "O momento atual é propício para estudos de entrada a longo prazo, considerando os fundamentos sólidos.",
-          "conclusion": "Os dados indicam que a empresa possui fundamentos robustos e excelente capacidade de gerar valor ao acionista, sendo uma boa opção para compor carteira. (OBS: Este é um resultado MOCK gerado para testes, pois a chave da API não foi configurada).",
-          "risk_assessment": "Baixo",
-          "disclaimer": "Esta análise é informativa e baseada em dados históricos. Não constitui recomendação de investimento."
-        }
-        """
+        logger.error("ANTHROPIC_API_KEY não configurada. Análise via LLM indisponível.")
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "A chave da API Anthropic (ANTHROPIC_API_KEY) não está configurada. "
+                "Defina a variável de ambiente no arquivo .env para habilitar a análise via IA."
+            ),
+        )
 
     try:
         client = anthropic.Anthropic(api_key=api_key)

--- a/frontend/src/pages/Analysis.jsx
+++ b/frontend/src/pages/Analysis.jsx
@@ -335,30 +335,45 @@ function filterHistory(history, period) {
 // ── Main component ───────────────────────────────────────────────────────────
 
 export default function Analysis({ ticker, onSearch, onComingSoon }) {
-  const [loading, setLoading]       = useState(false);
-  const [tickerData, setTickerData] = useState(null);
-  const [analysisData, setAnalysis] = useState(null);
-  const [error, setError]           = useState(null);
-  const [activeTab, setActiveTab]   = useState('overview');
-  const [period, setPeriod]         = useState('1A');
+  const [loading, setLoading]         = useState(false);
+  const [tickerData, setTickerData]   = useState(null);
+  const [analysisData, setAnalysis]   = useState(null);
+  const [analysisLoading, setAnalysisLoading] = useState(false);
+  const [analysisError, setAnalysisError]     = useState(null);
+  const [error, setError]             = useState(null);
+  const [activeTab, setActiveTab]     = useState('overview');
+  const [period, setPeriod]           = useState('1A');
   const [showScoreModal, setShowScoreModal] = useState(false);
 
+  // Carrega apenas dados do ticker (cotação + indicadores + histórico)
   const fetchData = async (symbol) => {
     setLoading(true);
     setTickerData(null);
     setAnalysis(null);
     setError(null);
+    setAnalysisError(null);
     try {
-      const [td, ad] = await Promise.all([
-        getTickerData(symbol),
-        getAnalysis(symbol, 'haiku', true),
-      ]);
+      const td = await getTickerData(symbol);
       setTickerData(td);
-      setAnalysis(ad);
     } catch (err) {
       setError(err);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Carrega análise via Anthropic — chamado apenas quando o usuário abre a aba IA
+  const fetchAnalysis = async (symbol) => {
+    if (analysisData) return; // já carregado, não refaz
+    setAnalysisLoading(true);
+    setAnalysisError(null);
+    try {
+      const ad = await getAnalysis(symbol, 'haiku', true);
+      setAnalysis(ad);
+    } catch (err) {
+      setAnalysisError(err);
+    } finally {
+      setAnalysisLoading(false);
     }
   };
 
@@ -368,6 +383,14 @@ export default function Analysis({ ticker, onSearch, onComingSoon }) {
       fetchData(ticker);
     }
   }, [ticker]);
+
+  // Quando o usuário clica na aba IA, dispara a chamada à Anthropic
+  const handleTabChange = (tabId) => {
+    setActiveTab(tabId);
+    if (tabId === 'ai' && ticker) {
+      fetchAnalysis(ticker);
+    }
+  };
 
   const filteredHistory = useMemo(
     () => filterHistory(tickerData?.price_history, period),
@@ -383,7 +406,7 @@ export default function Analysis({ ticker, onSearch, onComingSoon }) {
       onHome={() => onSearch(null)}
     />
   );
-  if (!tickerData || !analysisData) return null;
+  if (!tickerData) return null;
 
   const { quote, indicators, asset_type, name, sector, segment } = tickerData;
   const isStock = asset_type !== 'fii';
@@ -391,8 +414,8 @@ export default function Analysis({ ticker, onSearch, onComingSoon }) {
   const change  = quote?.change_percent;
   const isUp    = (change ?? 0) >= 0;
 
-  // Use score from ticker endpoint (calculated from indicators), fallback to analysis score
-  const displayScore = tickerData.score?.score ?? analysisData.score ?? 0;
+  // Score vem do endpoint do ticker (calculado a partir dos indicadores reais)
+  const displayScore = tickerData.score?.score ?? 0;
 
   // Logo initials
   const logoText = (tickerData.ticker || ticker || '').slice(0, 2).toUpperCase();
@@ -502,7 +525,7 @@ export default function Analysis({ ticker, onSearch, onComingSoon }) {
           <button
             key={tab.id}
             className={`analysis-tab${activeTab === tab.id ? ' analysis-tab-active' : ''}`}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => handleTabChange(tab.id)}
           >
             {tab.label}
             {tab.badge && <span className="tab-badge-new">{tab.badge}</span>}
@@ -672,7 +695,33 @@ export default function Analysis({ ticker, onSearch, onComingSoon }) {
       )}
 
       {activeTab === 'ai' && (
-        <Verdict analysisData={analysisData} />
+        <>
+          {analysisLoading && (
+            <div className="tab-placeholder">
+              <div className="tab-placeholder-icon">🤖</div>
+              <div>Gerando análise com Inteligência Artificial...</div>
+            </div>
+          )}
+          {analysisError && !analysisLoading && (
+            <div className="tab-placeholder">
+              <div className="tab-placeholder-icon">⚠️</div>
+              <div style={{ color: 'var(--danger)', marginBottom: '0.75rem' }}>
+                {typeof analysisError === 'string'
+                  ? analysisError
+                  : analysisError?.detail || 'Erro ao gerar análise via IA.'}
+              </div>
+              <button
+                className="btn-primary"
+                onClick={() => { setAnalysis(null); fetchAnalysis(ticker); }}
+              >
+                Tentar novamente
+              </button>
+            </div>
+          )}
+          {analysisData && !analysisLoading && (
+            <Verdict analysisData={analysisData} />
+          )}
+        </>
       )}
 
       {activeTab === 'history' && (


### PR DESCRIPTION
## Contexto

A falta de configuração da chave da anthropic estava fazendo com que o backend retornasse dados genéricos de um mock na aba IA para todos os ativos pesquisados.

## O que foi feito

Feita a separação das requests de pesquisa comum (tela principal) e chamada para o claud.

Implementada mensagem de retorno com status code 503 apenas na aba IA quando a chave da anthropic não está configurada.

## Como testar

Clicar na aba IA sem chave da anthropic configurada.


## Screenshots/Logs (opcional)

<img width="2502" height="1242" alt="image" src="https://github.com/user-attachments/assets/e799b87e-36c0-48e8-81d8-4946e2892712" />


